### PR TITLE
Correct README to reflect application state

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Edit it
 
 ```ruby
 class PhoneNumber < ActiveRecord::Base
-  belongs_to :contact
+  has_one :contact
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Edit the model
 ```ruby
 class Contact < ActiveRecord::Base
   has_many :phone_numbers
+
+  ### Validations
+  validates :name_first, presence: true
+  validates :name_last, presence: true
+
 end
 ```
 


### PR DESCRIPTION
The README as it stands doesn't include validations, so following the instructions won't result in the validation failure at the end of the tutorial.

Also corrected belongs_to to has_one in the model description, to match app/models/phone_number.rb. Arguably belongs_to is correct, but since jsonapi-resources doesn't seem to support belongs_to in the resource object, it seems reasonable to be consistent and use has_one in both places.

On a side note, I found that the link between the contact and the phone_number doesn't get created (contact_id is not set) when using jsonapi-resources 0.3.1. I'm too new to this to track down the source of the bug, so I'm just going to file it as a bug here.